### PR TITLE
fix missing dash in grep command

### DIFF
--- a/convert_ti_ble_sdk_2_02_01_18_to_linux.sh
+++ b/convert_ti_ble_sdk_2_02_01_18_to_linux.sh
@@ -102,7 +102,7 @@ function replace_text_in_ble_sdk {
 
 function replace_text_in_tirtos {
 	echo -e "Changing $1 to $2 in all tirtos source files"
-	grep --exclude-dir=".git" -exclude=*.a -rl "$1" ${TIRTOS_DIRECTORY} | xargs sed -i "s/$1/$2/g"
+	grep --exclude-dir=".git" --exclude=*.a -rl "$1" ${TIRTOS_DIRECTORY} | xargs sed -i "s/$1/$2/g"
 }
 
 # There's an invalid linked location in ${BLE_SDK_DIRECTORY}/examples/cc2650stk/sensortag_lcd/ccs/app/.project

--- a/convert_ti_simplelink_academy_01_11_00_0000_to_linux.sh
+++ b/convert_ti_simplelink_academy_01_11_00_0000_to_linux.sh
@@ -102,7 +102,7 @@ function replace_text_in_ble_sdk {
 
 function replace_text_in_tirtos {
 	echo -e "Changing $1 to $2 in all tirtos source files"
-	grep --exclude-dir=".git" -exclude=*.a -rl "$1" ${TIRTOS_DIRECTORY} | xargs sed -i "s/$1/$2/g"
+	grep --exclude-dir=".git" --exclude=*.a -rl "$1" ${TIRTOS_DIRECTORY} | xargs sed -i "s/$1/$2/g"
 }
 
 # There's an invalid linked location in ${BLE_SDK_DIRECTORY}/examples/cc2650stk/sensortag_lcd/ccs/app/.project


### PR DESCRIPTION
The grep command is broken otherwise (at least for grep 3.0).