### PR TITLE
patch for ti_ble_sdk_2_02_01_18

### DIFF
--- a/ti_ble_sdk_2_02_01_18.patch
+++ b/ti_ble_sdk_2_02_01_18.patch
@@ -1,0 +1,4651 @@
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/app/.project	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/app/.project	2017-06-21 04:32:09.317098633 -0400
+@@ -327,14 +327,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -435,7 +435,7 @@
+   <variableList>
+     <variable>
+       <name>CC13XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -459,7 +459,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.cproject	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.cproject	2017-06-21 04:32:09.317098633 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${BuildArtifactFileName};${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${BuildArtifactFileName};${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1803287634" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.2069595691">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1309998768" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.project	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/dual_image_concept/ccs/stack/.project	2017-06-21 04:32:09.317098633 -0400
+@@ -316,9 +316,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -424,11 +424,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -452,7 +452,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/app/.project	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/app/.project	2017-06-21 04:32:09.317098633 -0400
+@@ -267,14 +267,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -397,30 +397,30 @@
+       <locationURI>SRC_COMMON/npi/src/inc/npi_tl.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_SPI.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_spi.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_SPI.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_spi.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.c</name>
++      <name>NPI/Transport/UART/npi_tl_uart.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_UART.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_uart.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.h</name>
++      <name>NPI/Transport/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_UART.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_uart.h</locationURI>
+     </link>
+   </linkedResources>
+   <variableList>
+     <variable>
+       <name>CC13XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -444,7 +444,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.cproject	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.cproject	2017-06-21 04:32:09.317098633 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1795421839" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.290569484">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1856112055" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.project	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/host_test/ccs/stack/.project	2017-06-21 04:32:09.317098633 -0400
+@@ -341,9 +341,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -449,11 +449,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -477,7 +477,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/app/.project	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/app/.project	2017-06-21 04:32:09.317098633 -0400
+@@ -77,9 +77,9 @@
+       <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag.h</locationURI>
+     </link>
+     <link>
+-      <name>Application/sensortag_Display.h</name>
++      <name>Application/sensortag_display.h</name>
+       <type>1</type>
+-      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_Display.h</locationURI>
++      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_display.h</locationURI>
+     </link>
+     <link>
+       <name>Application/sensortag_batt.c</name>
+@@ -555,7 +555,7 @@
+   <variableList>
+     <variable>
+       <name>CC13XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -579,7 +579,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.cproject	2017-06-21 04:29:46.237938982 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.cproject	2017-06-21 04:32:09.317098633 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1296670533" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.2063658713">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.848407485" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/sensortag/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -331,9 +331,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -287,14 +287,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -395,7 +395,7 @@
+   <variableList>
+     <variable>
+       <name>CC13XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -419,7 +419,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1299021922" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.875897321">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1030260971" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_broadcaster/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -311,9 +311,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -419,11 +419,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -447,7 +447,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -362,14 +362,14 @@
+ 			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>Drivers/Display/DisplayUART.c</name>
++			<name>Drivers/Display/DisplayUart.c</name>
+ 			<type>1</type>
+-			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>Drivers/Display/DisplayUART.h</name>
++			<name>Drivers/Display/DisplayUart.h</name>
+ 			<type>1</type>
+-			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -512,30 +512,30 @@
+ 			<locationURI>SRC_COMMON/npi/src/unified/inc/npi_util.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++			<name>NPI/Transport/SPI/npi_tl_spi.c</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/npi/src/unified/npi_tl_SPI.c</locationURI>
++			<locationURI>SRC_COMMON/npi/src/unified/npi_tl_spi.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++			<name>NPI/Transport/SPI/npi_tl_spi.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_SPI.h</locationURI>
++			<locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_spi.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>NPI/Transport/UART/npi_tl_UART.c</name>
++			<name>NPI/Transport/UART/npi_tl_uart.c</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/npi/src/unified/npi_tl_UART.c</locationURI>
++			<locationURI>SRC_COMMON/npi/src/unified/npi_tl_uart.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>NPI/Transport/UART/npi_tl_UART.h</name>
++			<name>NPI/Transport/UART/npi_tl_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_UART.h</locationURI>
++			<locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_uart.h</locationURI>
+ 		</link>
+ 	</linkedResources>
+ 	<variableList>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -559,7 +559,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1444184112" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.687799336">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1467557805" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -381,9 +381,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -444,11 +444,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -472,7 +472,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/iar/config/ccfg_app_ble.c b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/iar/config/ccfg_app_ble.c
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:32:09.327098574 -0400
+@@ -70,7 +70,7 @@
+ 
+ // Note: SNP_SBL_ENABLE should be defined to make Simple NP OAD upgradeable.
+ #ifdef SNP_SBL_ENABLE
+-#include "board.h"
++#include "Board.h"
+ 
+ #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5       // Enable
+ #define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5       // Enabled
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -372,14 +372,14 @@
+ 			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>Drivers/Display/DisplayUART.c</name>
++			<name>Drivers/Display/DisplayUart.c</name>
+ 			<type>1</type>
+-			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>Drivers/Display/DisplayUART.h</name>
++			<name>Drivers/Display/DisplayUart.h</name>
+ 			<type>1</type>
+-			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++			<locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -490,7 +490,7 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -514,7 +514,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc1350.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1673475627" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.592799836">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.2082572479" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc1350lp/simple_peripheral/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -367,14 +367,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -530,7 +530,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -554,7 +554,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.271937330" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.273223774">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1906151166" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -381,9 +381,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -444,11 +444,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -472,7 +472,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/iar/config/ccfg_app_ble.c b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/iar/config/ccfg_app_ble.c
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650bp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:32:09.327098574 -0400
+@@ -70,7 +70,7 @@
+ 
+ // Note: SNP_SBL_ENABLE should be defined to make Simple NP OAD upgradeable.
+ #ifdef SNP_SBL_ENABLE
+-#include "board.h"
++#include "Board.h"
+ 
+ #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5       // Enable
+ #define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5       // Enabled
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -367,14 +367,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -465,7 +465,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -489,7 +489,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1164555419" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.826250453">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1327751040" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/blood_pressure/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -330,7 +330,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -354,7 +354,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1922706277" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1760299338">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1400878009" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/cycling_sensor/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -347,14 +347,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -445,7 +445,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -469,7 +469,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1089456096" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1089456096" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1089456096." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.852202702" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1199318012">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.679456964" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_collector/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/app/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -337,14 +337,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -435,7 +435,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -459,7 +459,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.cproject	2017-06-21 04:32:09.327098574 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.680837019" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.680837019" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.680837019." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.495355884" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.230042395">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.117150959" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/glucose_sensor/ccs/stack/.project	2017-06-21 04:32:09.327098574 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -340,7 +340,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -364,7 +364,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.955637975" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.503382972">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.694356830" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/heart_rate/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -357,14 +357,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -455,7 +455,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -479,7 +479,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1799407229" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1625181437">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.2117039995" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/hid_emu_kbd/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -451,7 +451,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ROM</name>
+@@ -471,7 +471,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -287,14 +287,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -407,30 +407,30 @@
+       <locationURI>SRC_COMMON/npi/src/inc/npi_tl.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_SPI.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_spi.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_SPI.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_spi.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.c</name>
++      <name>NPI/Transport/UART/npi_tl_uart.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_UART.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_uart.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.h</name>
++      <name>NPI/Transport/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_UART.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_uart.h</locationURI>
+     </link>
+   </linkedResources>
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -454,7 +454,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.cproject	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1811322871" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.978846463">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1776978734" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/host_test/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -341,9 +341,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -449,11 +449,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -477,7 +477,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/app/.project	2017-06-21 04:29:46.247938923 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -377,14 +377,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -475,7 +475,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -499,7 +499,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.229557153" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.229557153" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.229557153." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1682426791" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.2096398909">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1690387894" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/key_fob/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -340,7 +340,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -364,7 +364,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1243186718" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1794745000">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1585906746" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/proximity_tag/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -330,7 +330,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -354,7 +354,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.699902359" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1740954628">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.510166778" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/running_sensor/ccs/stack/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_ap/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_ap/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_ap/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_ap/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -387,9 +387,9 @@
+       <locationURI>SAP/ti/npi/npi_tl.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/TL/UART/npi_tl_UART.h</name>
++      <name>NPI/TL/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SAP/ti/npi/npi_tl_UART.h</locationURI>
++      <locationURI>SAP/ti/npi/npi_tl_uart.h</locationURI>
+     </link>
+     <link>
+       <name>NPI/TL/UART/npi_tl_uart_m_cc26xx.c</name>
+@@ -400,7 +400,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>SAP</name>
+@@ -428,7 +428,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/app/.project	2017-06-21 04:32:09.337098516 -0400
+@@ -292,14 +292,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -390,7 +390,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -414,7 +414,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:32:09.337098516 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1433565849" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.647826345">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.576912283" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_broadcaster/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -356,9 +356,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -419,11 +419,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -447,7 +447,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -287,14 +287,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -385,7 +385,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -409,7 +409,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1709271573" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1709271573" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1709271573." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1628568718" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.873282257">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1023779966" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_central/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -367,14 +367,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -507,30 +507,30 @@
+       <locationURI>SRC_COMMON/npi/src/unified/inc/npi_util.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_SPI.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_spi.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_SPI.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_spi.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.c</name>
++      <name>NPI/Transport/UART/npi_tl_uart.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_UART.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_uart.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.h</name>
++      <name>NPI/Transport/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_UART.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_uart.h</locationURI>
+     </link>
+   </linkedResources>
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -554,7 +554,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.677230046" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.758643548">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.669405273" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -381,9 +381,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -444,11 +444,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -472,7 +472,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/iar/config/ccfg_app_ble.c b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/iar/config/ccfg_app_ble.c
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:32:09.347098457 -0400
+@@ -70,7 +70,7 @@
+ 
+ // Note: SNP_SBL_ENABLE should be defined to make Simple NP OAD upgradeable.
+ #ifdef SNP_SBL_ENABLE
+-#include "board.h"
++#include "Board.h"
+ 
+ #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5       // Enable
+ #define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5       // Enabled
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -287,14 +287,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -385,7 +385,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -409,7 +409,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1865576175" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1865576175" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1865576175." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.2086135512" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.303058128">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.847572952" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_observer/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -356,9 +356,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -419,11 +419,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -447,7 +447,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -387,14 +387,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -495,7 +495,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -523,7 +523,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1704115197" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1992400841">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.136228125" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/simple_peripheral/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -370,7 +370,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -394,7 +394,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.2035019015" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.142777942">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1792423061" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/thermometer/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/app/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -347,14 +347,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -445,7 +445,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -469,7 +469,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.cproject	2017-06-21 04:32:09.347098457 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1274219447" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1540988462">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.368887712" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650em/time_app/ccs/stack/.project	2017-06-21 04:32:09.347098457 -0400
+@@ -371,9 +371,9 @@
+       <locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+     </link>
+     <link>
+-      <name>HAL/Include/hal_UART.h</name>
++      <name>HAL/Include/hal_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++      <locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+     </link>
+     <link>
+       <name>HAL/Target/CC2650</name>
+@@ -434,11 +434,11 @@
+   <variableList>
+     <variable>
+       <name>BIOS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+     </variable>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -462,7 +462,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/app/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -277,14 +277,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -397,30 +397,30 @@
+       <locationURI>SRC_COMMON/npi/src/inc/npi_tl.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_SPI.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_spi.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_SPI.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_spi.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.c</name>
++      <name>NPI/Transport/UART/npi_tl_uart.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/npi_tl_UART.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/npi_tl_uart.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.h</name>
++      <name>NPI/Transport/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_UART.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/inc/npi_tl_uart.h</locationURI>
+     </link>
+   </linkedResources>
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -444,7 +444,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.cproject	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.893345658." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.360859556" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.589698683">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.271002943" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.project	2017-06-21 04:29:46.257938864 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/host_test/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -386,9 +386,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -449,11 +449,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -477,7 +477,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -117,9 +117,9 @@
+       <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_display.c</locationURI>
+     </link>
+     <link>
+-      <name>Application/sensortag_Display.h</name>
++      <name>Application/sensortag_display.h</name>
+       <type>1</type>
+-      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_Display.h</locationURI>
++      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_display.h</locationURI>
+     </link>
+     <link>
+       <name>Application/sensortag_factoryreset.c</name>
+@@ -555,7 +555,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -579,7 +579,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1586583415" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1530637115">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1309278682" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/sensortag/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_ap/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_ap/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_ap/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_ap/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -467,9 +467,9 @@
+       <locationURI>SAP/ti/npi/npi_tl_cc26xx.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/TL/UART/npi_tl_UART.h</name>
++      <name>NPI/TL/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SAP/ti/npi/npi_tl_UART.h</locationURI>
++      <locationURI>SAP/ti/npi/npi_tl_uart.h</locationURI>
+     </link>
+     <link>
+       <name>NPI/TL/UART/npi_tl_uart_m_cc26xx.c</name>
+@@ -480,7 +480,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -508,7 +508,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -297,14 +297,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -395,7 +395,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -419,7 +419,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1375801446." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.674818852" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.472296000">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.306531906" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_broadcaster/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -356,9 +356,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -419,11 +419,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -447,7 +447,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -372,14 +372,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -512,30 +512,30 @@
+       <locationURI>SRC_COMMON/npi/src/unified/inc/npi_util.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.c</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_SPI.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_spi.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/SPI/npi_tl_SPI.h</name>
++      <name>NPI/Transport/SPI/npi_tl_spi.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_SPI.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_spi.h</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.c</name>
++      <name>NPI/Transport/UART/npi_tl_uart.c</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_UART.c</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/npi_tl_uart.c</locationURI>
+     </link>
+     <link>
+-      <name>NPI/Transport/UART/npi_tl_UART.h</name>
++      <name>NPI/Transport/UART/npi_tl_uart.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_UART.h</locationURI>
++      <locationURI>SRC_COMMON/npi/src/unified/inc/npi_tl_uart.h</locationURI>
+     </link>
+   </linkedResources>
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -559,7 +559,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.803824411" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1974359279">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.199011429" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -381,9 +381,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -444,11 +444,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -472,7 +472,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/iar/config/ccfg_app_ble.c b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/iar/config/ccfg_app_ble.c
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_np/iar/config/ccfg_app_ble.c	2017-06-21 04:32:09.357098398 -0400
+@@ -70,7 +70,7 @@
+ 
+ // Note: SNP_SBL_ENABLE should be defined to make Simple NP OAD upgradeable.
+ #ifdef SNP_SBL_ENABLE
+-#include "board.h"
++#include "Board.h"
+ 
+ #define SET_CCFG_BL_CONFIG_BOOTLOADER_ENABLE            0xC5       // Enable
+ #define SET_CCFG_BL_CONFIG_BL_ENABLE                    0xC5       // Enabled
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -377,14 +377,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/PIN/PIN.h</name>
+@@ -485,7 +485,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -509,7 +509,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1246939502" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.879136471">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1825930930" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650lp/simple_peripheral/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/app/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -440,7 +440,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -464,7 +464,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.cproject	2017-06-21 04:32:09.357098398 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.81544433." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.50032268" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1765036621">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.627475769" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650rc/hid_adv_remote/ccs/stack/.project	2017-06-21 04:32:09.357098398 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -471,7 +471,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/app/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -547,9 +547,9 @@
+       <locationURI>SRC_EX/target/board.c</locationURI>
+     </link>
+     <link>
+-      <name>Startup/board.h</name>
++      <name>Startup/Board.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/hal/src/target/board.h</locationURI>
++      <locationURI>SRC_COMMON/hal/src/target/Board.h</locationURI>
+     </link>
+     <link>
+       <name>Startup/ccfg_app_ble.c</name>
+@@ -765,7 +765,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -789,7 +789,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.cproject	2017-06-21 04:32:09.367098339 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1511511774" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.338291017">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1540770708" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag/ccs/stack/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -326,9 +326,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -434,11 +434,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -462,7 +462,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/app/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -562,9 +562,9 @@
+ 			<locationURI>SRC_EX/target/board.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>Startup/board.h</name>
++			<name>Startup/Board.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/target/board.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/target/Board.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>Startup/ccfg_app_ble.c</name>
+@@ -800,7 +800,7 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -824,7 +824,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.cproject	2017-06-21 04:32:09.367098339 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234.369398323" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd;" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234.369398323" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd;" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234.369398323." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.408146281" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.338291017">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.874534645" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_audio/ccs/stack/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -326,9 +326,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -434,11 +434,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -462,7 +462,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/app/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -97,9 +97,9 @@
+       <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag.h</locationURI>
+     </link>
+     <link>
+-      <name>Application/sensortag_Display.h</name>
++      <name>Application/sensortag_display.h</name>
+       <type>1</type>
+-      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_Display.h</locationURI>
++      <locationURI>SRC_EX/examples/sensortag/cc26xx/app/sensortag_display.h</locationURI>
+     </link>
+     <link>
+       <name>Application/sensortag_bar.c</name>
+@@ -577,9 +577,9 @@
+       <locationURI>SRC_EX/target/board.c</locationURI>
+     </link>
+     <link>
+-      <name>Startup/board.h</name>
++      <name>Startup/Board.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/hal/src/target/_common/board.h</locationURI>
++      <locationURI>SRC_EX/target/Board.h</locationURI>
+     </link>
+     <link>
+       <name>Startup/ccfg_app_ble.c</name>
+@@ -840,7 +840,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -864,7 +864,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.cproject	2017-06-21 04:32:09.367098339 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1511511774" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.338291017">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1540770708" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_lcd/ccs/stack/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -326,9 +326,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -434,11 +434,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -462,7 +462,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/app/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -462,9 +462,9 @@
+       <locationURI>SRC_EX/target/board.c</locationURI>
+     </link>
+     <link>
+-      <name>Startup/board.h</name>
++      <name>Startup/Board.h</name>
+       <type>1</type>
+-      <locationURI>SRC_COMMON/hal/src/target/_common/board.h</locationURI>
++      <locationURI>SRC_EX/target/Board.h</locationURI>
+     </link>
+     <link>
+       <name>Startup/ccfg_app_ble.c</name>
+@@ -675,7 +675,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -699,7 +699,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.cproject	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.cproject	2017-06-21 04:32:09.367098339 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../config/ccs_linker_defines.cmd " prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib ${ORG_PROJ_DIR}/../config/lib_linker.cmd">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1739398234." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.1511511774" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.338291017">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.1540770708" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/sensortag_light/ccs/stack/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -326,9 +326,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/common/hal_assert.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Include/hal_adc.h</name>
+@@ -434,11 +434,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -462,7 +462,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/app/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/app/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/app/.project	2017-06-21 04:29:46.267938805 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/app/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -362,14 +362,14 @@
+       <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayDogm1286.h</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.c</name>
++      <name>Drivers/Display/DisplayUart.c</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.c</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.c</locationURI>
+     </link>
+     <link>
+-      <name>Drivers/Display/DisplayUART.h</name>
++      <name>Drivers/Display/DisplayUart.h</name>
+       <type>1</type>
+-      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUART.h</locationURI>
++      <locationURI>TI_RTOS_DRIVERS_BASE/ti/mw/display/DisplayUart.h</locationURI>
+     </link>
+     <link>
+       <name>Drivers/ECC/ECCROMCC26XX.c</name>
+@@ -480,7 +480,7 @@
+   <variableList>
+     <variable>
+       <name>CC26XXWARE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+     </variable>
+     <variable>
+       <name>ORG_PROJ_DIR</name>
+@@ -504,7 +504,7 @@
+     </variable>
+     <variable>
+       <name>TI_RTOS_DRIVERS_BASE</name>
+-      <value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++      <value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+     </variable>
+     <variable>
+       <name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.cproject b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.cproject
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.cproject	2017-06-21 04:32:09.367098339 -0400
+@@ -12,7 +12,7 @@
+         </extensions>
+       </storageModule>
+       <storageModule moduleId="cdtBuildSystem" version="4.0.0">
+-        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="&quot;${TOOLS_BLE}/lib_search/lib_search.exe&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
++        <configuration artifactExtension="out" artifactName="${ProjName}" buildProperties="" cleanCommand="${CG_CLEAN_CMD}" description="" id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684" name="FlashROM" parent="com.ti.ccstudio.buildDefinitions.TMS470.Default" postannouncebuildStep="" postbuildStep="${CG_TOOL_HEX} -order MS --memwidth=8 --romwidth=8 --intel -o ${ProjName}.hex ${ProjName}.out;${TOOLS_BLE}/frontier/frontier.exe ccs ${PROJECT_LOC}/${ConfigName}/${ProjName}_linkInfo.xml ${ORG_PROJ_DIR}/../../ccs/config/ccs_compiler_defines.bcfg ${ORG_PROJ_DIR}/../../ccs/config/ccs_linker_defines.cmd" preannouncebuildStep="" prebuildStep="python &quot;${TOOLS_BLE}/lib_search/src/lib_search.py&quot; ${ORG_PROJ_DIR}/build_config.opt &quot;${TOOLS_BLE}/lib_search/params_split_cc2640.xml&quot; ${SRC_BLE_CORE}/../blelib &quot;${ORG_PROJ_DIR}/../../ccs/config/lib_linker.cmd&quot;">
+           <folderInfo id="com.ti.ccstudio.buildDefinitions.TMS470.Default.1209999684." name="/" resourcePath="">
+             <toolChain id="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain.858015066" name="TI Build Tools" superClass="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.DebugToolchain" targetTool="com.ti.ccstudio.buildDefinitions.TMS470_5.2.exe.linkerDebug.1328742856">
+               <option id="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS.78395267" superClass="com.ti.ccstudio.buildDefinitions.core.OPT_TAGS" valueType="stringList">
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.project b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.project	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/cc2650stk/simple_peripheral/ccs/stack/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -376,9 +376,9 @@
+ 			<locationURI>SRC_COMMON/hal/src/inc/hal_timer.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>HAL/Include/hal_UART.h</name>
++			<name>HAL/Include/hal_uart.h</name>
+ 			<type>1</type>
+-			<locationURI>SRC_COMMON/hal/src/inc/hal_UART.h</locationURI>
++			<locationURI>SRC_COMMON/hal/src/inc/hal_uart.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>HAL/Target/CC2650</name>
+@@ -439,11 +439,11 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>BIOS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/bios_6_46_01_38/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+@@ -467,7 +467,7 @@
+ 		</variable>
+ 		<variable>
+ 			<name>TI_RTOS_DRIVERS_BASE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages</value>
+ 		</variable>
+ 		<variable>
+ 			<name>TOOLS_BLE</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/util/bim/cc1350lp/ccs/.project b/simplelink/ble_sdk_2_02_01_18/examples/util/bim/cc1350lp/ccs/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/util/bim/cc1350lp/ccs/.project	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/util/bim/cc1350lp/ccs/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -59,7 +59,7 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc1350/ccs/.project b/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc1350/ccs/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc1350/ccs/.project	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc1350/ccs/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -81,14 +81,14 @@
+ 			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/ext_flash.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>SPI/bsp_SPI.c</name>
++			<name>SPI/bsp_spi.c</name>
+ 			<type>1</type>
+-			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_SPI.c</locationURI>
++			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_spi.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>SPI/bsp_SPI.h</name>
++			<name>SPI/bsp_spi.h</name>
+ 			<type>1</type>
+-			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_SPI.h</locationURI>
++			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_spi.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>TOOLS/cc26xx_bim_ext_flash.cmd</name>
+@@ -99,7 +99,7 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>CC13XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc13xxware_2_04_02_17240</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc2640/ccs/.project b/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc2640/ccs/.project
+--- a/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc2640/ccs/.project	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/examples/util/bim_extflash/cc2640/ccs/.project	2017-06-21 04:32:09.367098339 -0400
+@@ -81,14 +81,14 @@
+ 			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/ext_flash.h</locationURI>
+ 		</link>
+ 		<link>
+-			<name>SPI/bsp_SPI.c</name>
++			<name>SPI/bsp_spi.c</name>
+ 			<type>1</type>
+-			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_SPI.c</locationURI>
++			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_spi.c</locationURI>
+ 		</link>
+ 		<link>
+-			<name>SPI/bsp_SPI.h</name>
++			<name>SPI/bsp_spi.h</name>
+ 			<type>1</type>
+-			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_SPI.h</locationURI>
++			<locationURI>$%7BSRC_EX%7D/examples/util/bim_extflash/cc2640/board/bsp_spi.h</locationURI>
+ 		</link>
+ 		<link>
+ 			<name>TOOLS/cc26xx_bim_ext_flash.cmd</name>
+@@ -99,7 +99,7 @@
+ 	<variableList>
+ 		<variable>
+ 			<name>CC26XXWARE</name>
+-			<value>file:/C:/ti/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
++			<value>${PARENT-7-ORG_PROJ_DIR}/tirtos_cc13xx_cc26xx_2_20_01_08/products/cc26xxware_2_24_02_17393</value>
+ 		</variable>
+ 		<variable>
+ 			<name>ORG_PROJ_DIR</name>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/npi/npi_util.h b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/npi/npi_util.h
+--- a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/npi/npi_util.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/npi/npi_util.h	2017-06-21 04:32:09.367098339 -0400
+@@ -43,7 +43,7 @@
+ // ****************************************************************************
+ 
+ #ifdef USE_ICALL
+-#include "ICall.h"
++#include "icall.h"
+ #else
+ #include <stdlib.h>
+ #endif //USE_ICALL
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl.c b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl.c
+--- a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl.c	2017-06-21 04:32:09.367098339 -0400
+@@ -46,7 +46,7 @@
+ 
+ #include <ti/drivers/UART.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_cc26xx.c b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_cc26xx.c
+--- a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_cc26xx.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_cc26xx.c	2017-06-21 04:32:09.367098339 -0400
+@@ -43,7 +43,7 @@
+ #include "sbl_internal.h"
+ #include "sbl.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_msp.c b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_msp.c
+--- a/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_msp.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/sap_3_00_01_07/source/ti/sbl/sbl_msp.c	2017-06-21 04:32:09.377098281 -0400
+@@ -45,7 +45,7 @@
+ #include <ti/drivers/GPIO.h>
+ #include <ti/drivers/UART.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/board_key.c b/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/board_key.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/board_key.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/board_key.c	2017-06-21 04:32:09.377098281 -0400
+@@ -63,7 +63,7 @@
+ 
+ #include "util.h"
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * TYPEDEFS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/time/time_clock.c b/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/time/time_clock.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/time/time_clock.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/common/cc26xx/time/time_clock.c	2017-06-21 04:32:09.377098281 -0400
+@@ -52,7 +52,7 @@
+ 
+ #include "bcomdef.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "utc_clock.h"
+ #include "time_clock.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/common/hal_drivers.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/common/hal_drivers.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/common/hal_drivers.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/common/hal_drivers.c	2017-06-21 04:32:09.377098281 -0400
+@@ -69,7 +69,7 @@
+ #ifdef CC2591_COMPRESSION_WORKAROUND
+ #include "mac_rx.h"
+ #endif
+-#include "OSAL.h"
++#include "osal.h"
+ #if defined POWER_SAVING
+ #include "OSAL_PwrMgr.h"
+ #endif
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.c	2017-06-21 04:32:09.377098281 -0400
+@@ -61,9 +61,9 @@
+ #include <ti/drivers/pin/PINCC26XX.h>
+ #include <string.h>
+ #include <inc/hw_ints.h>
+-#include "ICall.h"
++#include "icall.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "key_scan.h"
+ #include "util.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.h b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/cc2650rc/key_scan.h	2017-06-21 04:32:09.377098281 -0400
+@@ -56,7 +56,7 @@
+  * INCLUDES
+  */
+ #include "hal_types.h"
+-#include "board.h"
++#include "Board.h"
+ #include "kcb.h"
+ 
+ /******************************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_aes.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_aes.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_aes.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_aes.c	2017-06-21 04:32:09.377098281 -0400
+@@ -47,7 +47,7 @@
+ /******************************************************************************
+  * INCLUDES
+  */
+-#include "OSAL.h"
++#include "osal.h"
+ #include "hal_aes.h"
+ #include "hal_mcu.h"
+ #include "hal_ccm.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_ccm.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_ccm.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_ccm.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_ccm.c	2017-06-21 04:32:09.377098281 -0400
+@@ -48,7 +48,7 @@
+  * INCLUDES
+  */
+ 
+-#include "OSAL.h"
++#include "osal.h"
+ #include "hal_aes.h"
+ #include "hal_ccm.h"
+ #include "hal_assert.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_mcu.h b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_mcu.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_mcu.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_mcu.h	2017-06-21 04:32:09.377098281 -0400
+@@ -106,7 +106,7 @@
+  */
+ 
+ #ifdef USE_ICALL
+-#include <ICall.h>
++#include <icall.h>
+ 
+ typedef ICall_CSState halIntState_t;
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_rtc_wrapper.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_rtc_wrapper.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_rtc_wrapper.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/hal_rtc_wrapper.c	2017-06-21 04:32:09.377098281 -0400
+@@ -55,7 +55,7 @@
+ #include <inc/hw_aon_rtc.h>
+ #include <driverlib/aon_rtc.h>
+ #include <driverlib/aon_event.h>
+-#include "ICall.h"
++#include "icall.h"
+ 
+ /*******************************************************************************
+  * MACROS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/system_init.c b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/system_init.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/system_init.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/hal/src/target/_common/system_init.c	2017-06-21 04:32:09.377098281 -0400
+@@ -47,7 +47,7 @@
+ /*******************************************************************************
+  * INCLUDES
+  */
+-#include <ICall.h>
++#include <icall.h>
+ #include <inc/hw_memmap.h>
+ #include "hal_types.h"
+ #include <inc/hw_types.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/icall/src/icall_platform.h b/simplelink/ble_sdk_2_02_01_18/src/components/icall/src/icall_platform.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/icall/src/icall_platform.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/icall/src/icall_platform.h	2017-06-21 04:32:09.377098281 -0400
+@@ -48,7 +48,7 @@
+ 
+ #include <stdint.h>
+ 
+-#include "ICall.h"
++#include "icall.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_ble.h b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_ble.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_ble.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_ble.h	2017-06-21 04:32:09.377098281 -0400
+@@ -55,7 +55,7 @@
+ // includes
+ // ****************************************************************************
+ #include "hal_types.h"
+-#include "OSAL.h"
++#include "osal.h"
+ 
+ // ****************************************************************************
+ // defines
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_client.h b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_client.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_client.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_client.h	2017-06-21 04:32:09.377098281 -0400
+@@ -55,7 +55,7 @@
+ // includes
+ // ****************************************************************************
+ #include "hal_types.h"
+-#include <ICall.h>
++#include <icall.h>
+ 
+ // ****************************************************************************
+ // defines
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_rxbuf.h b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_rxbuf.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_rxbuf.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/inc/npi_rxbuf.h	2017-06-21 04:32:09.377098281 -0400
+@@ -55,7 +55,7 @@
+ // includes
+ // ****************************************************************************
+ #include "hal_types.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "npi_config.h"
+ 
+ // ****************************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_client_mt.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_client_mt.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_client_mt.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_client_mt.c	2017-06-21 04:32:09.377098281 -0400
+@@ -50,7 +50,7 @@
+ // ****************************************************************************
+ #include "inc/npi_client.h"
+ #include "inc/npi_data.h"
+-#include <ICall.h>
++#include <icall.h>
+ #include <stdint.h>
+ #include <string.h>
+ #include "MT_RPC.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_frame_hci.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_frame_hci.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_frame_hci.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_frame_hci.c	2017-06-21 04:32:09.377098281 -0400
+@@ -55,8 +55,8 @@
+ #include "inc/npi_rxbuf.h"
+ #include "inc/npi_frame.h"
+ 
+-#include "OSAL.h"
+-#include "ICall.h"
++#include "osal.h"
++#include "icall.h"
+ #include <Board.h>
+ #include "hal_types.h"
+ #include "hci_tl.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_task.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_task.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_task.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_task.c	2017-06-21 04:32:09.377098281 -0400
+@@ -61,7 +61,7 @@
+ #include <ti/sysbios/BIOS.h>
+ 
+ #include <string.h>
+-#include "ICall.h"
++#include "icall.h"
+ 
+ #include "inc/npi_task.h"
+ #include "inc/npi_data.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl.c	2017-06-21 04:32:09.377098281 -0400
+@@ -59,7 +59,7 @@
+ #include "inc/hw_memmap.h"
+ #include "inc/hw_ints.h"
+ #include <Board.h>
+-#include "ICall.h"
++#include "icall.h"
+ #include "hal_types.h"
+ #include "inc/npi_tl.h"
+ #include "inc/npi_config.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_spi.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_spi.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_spi.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_spi.c	2017-06-21 04:32:09.377098281 -0400
+@@ -54,7 +54,7 @@
+ #include "inc/hw_ints.h"
+ #include <Board.h>
+ #include "hal_types.h"
+-#include "ICall.h"
++#include "icall.h"
+ #include <ti/sysbios/knl/Task.h>
+ #include <ti/sysbios/knl/Swi.h>
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_uart.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_uart.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_uart.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/npi_tl_uart.c	2017-06-21 04:32:09.377098281 -0400
+@@ -52,7 +52,7 @@
+ #include <ti/sysbios/family/arm/m3/Hwi.h>
+ #include "inc/hw_memmap.h"
+ #include "inc/hw_ints.h"
+-#include "ICall.h"
++#include "icall.h"
+ #include <Board.h>
+ #include "hal_types.h"
+ #include <ti/sysbios/knl/Task.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/inc/npi_util.h b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/inc/npi_util.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/inc/npi_util.h	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/inc/npi_util.h	2017-06-21 04:32:09.377098281 -0400
+@@ -56,7 +56,7 @@
+ // ****************************************************************************
+   
+ #ifdef USE_ICALL
+-#include "ICall.h"
++#include "icall.h"
+ #else
+ #include <stdlib.h>
+ #endif //USE_ICALL
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/npi_tl_spi.c b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/npi_tl_spi.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/npi_tl_spi.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/npi/src/unified/npi_tl_spi.c	2017-06-21 04:32:09.377098281 -0400
+@@ -53,7 +53,7 @@
+ #include "inc/hw_memmap.h"
+ #include "inc/hw_ints.h"
+ #include "hal_types.h"
+-#include "ICall.h"
++#include "icall.h"
+ #include <ti/sysbios/knl/Task.h>
+ #include <ti/sysbios/knl/Swi.h>
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal.c	2017-06-21 04:32:09.377098281 -0400
+@@ -75,7 +75,7 @@
+ #ifdef ICALL_JT
+   #include "icall_JT.h"
+ #else
+-  #include <ICall.h>
++  #include <icall.h>
+ #endif /* ICALL_JT */   
+ #endif /* USE_ICALL */
+ 
+@@ -1340,7 +1340,7 @@
+  * @brief
+  *
+  *   This function initializes the "task" system by creating the
+- *   tasks defined in the task table (OSAL_Tasks.h).
++ *   tasks defined in the task table (osal_tasks.h).
+  *
+  * @param   void
+  *
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_cbtimer.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_cbtimer.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_cbtimer.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_cbtimer.c	2017-06-21 04:32:09.377098281 -0400
+@@ -47,8 +47,8 @@
+  Release Date: 2016-10-26 15:20:04
+  *****************************************************************************/
+ 
+-#include "OSAL.h"
+-#include "OSAL_Tasks.h"
++#include "osal.h"
++#include "osal_tasks.h"
+ 
+ #include "hal_mcu.h"
+ #include "osal_cbtimer.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_clock_ble.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_clock_ble.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_clock_ble.c	2017-06-21 04:29:46.277938747 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_clock_ble.c	2017-06-21 04:32:09.387098222 -0400
+@@ -50,7 +50,7 @@
+ 
+ #include "comdef.h"
+ #include "OnBoard.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "OSAL_Clock.h"
+ 
+ /*********************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory.c	2017-06-21 04:32:09.387098222 -0400
+@@ -54,8 +54,8 @@
+ #include <stdlib.h>
+ 
+ #include "comdef.h"
+-#include "OSAL.h"
+-#include "OSAL_Memory.h"
++#include "osal.h"
++#include "osal_memory.h"
+ #include "OnBoard.h"
+ #include "hal_mcu.h"
+ #include "hal_assert.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory_icall.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory_icall.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory_icall.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_memory_icall.c	2017-06-21 04:32:09.387098222 -0400
+@@ -51,13 +51,13 @@
+  */
+ 
+ #include "comdef.h"
+-#include "OSAL.h"
+-#include "OSAL_Memory.h"
++#include "osal.h"
++#include "osal_memory.h"
+ 
+ #ifdef ICALL_JT
+ #include "icall_JT.h"
+ #else
+-#include <ICall.h>
++#include <icall.h>
+ #endif /* ICALL_JT */   
+ 
+ /**************************************************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_pwrmgr.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_pwrmgr.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_pwrmgr.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/common/osal_pwrmgr.c	2017-06-21 04:32:09.387098222 -0400
+@@ -59,7 +59,7 @@
+ #ifdef ICALL_JT
+   #include "icall_JT.h"
+ #else
+-  #include <ICall.h>
++  #include <icall.h>
+ #endif /* ICALL_JT */   
+ #endif /* USE_ICALL */
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/inc/osal.h b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/inc/osal.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/inc/osal.h	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/inc/osal.h	2017-06-21 04:32:09.387098222 -0400
+@@ -62,11 +62,11 @@
+ #include <limits.h>
+ 
+ #include "comdef.h"
+-#include "OSAL_Memory.h"
+-#include "OSAL_Timers.h"
++#include "osal_memory.h"
++#include "osal_timers.h"
+ 
+ #ifdef USE_ICALL
+-#include <ICall.h>
++#include <icall.h>
+ #endif /* USE_ICALL */
+ 
+ /*********************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/mcu/cc26xx/osal_snv.c b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/mcu/cc26xx/osal_snv.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/mcu/cc26xx/osal_snv.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/osal/src/mcu/cc26xx/osal_snv.c	2017-06-21 04:32:09.387098222 -0400
+@@ -53,7 +53,7 @@
+ #include "hal_types.h"
+ #include "pwrmon.h"   
+ #include "comdef.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "osal_snv.h"
+ #include "hal_assert.h"
+ #include "saddr.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/sbl/src/cc26xx/sbl.c b/simplelink/ble_sdk_2_02_01_18/src/components/sbl/src/cc26xx/sbl.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/sbl/src/cc26xx/sbl.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/sbl/src/cc26xx/sbl.c	2017-06-21 04:32:09.387098222 -0400
+@@ -64,7 +64,7 @@
+ #if defined (CC2650_LAUNCHXL)
+ #include <board_lp.h>
+ #elif defined (CC2650STK)
+-#include "board.h"
++#include "Board.h"
+ #endif //CC2650_LAUNCHXL
+ 
+ /*********************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/services/src/nv/cc26xx/nvocop.c b/simplelink/ble_sdk_2_02_01_18/src/components/services/src/nv/cc26xx/nvocop.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/services/src/nv/cc26xx/nvocop.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/services/src/nv/cc26xx/nvocop.c	2017-06-21 04:32:09.387098222 -0400
+@@ -80,7 +80,7 @@
+ #include "hal_flash.h"
+ #include "hal_types.h"
+ #include "pwrmon.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "osal_snv.h"
+ #include "hal_assert.h"
+ #include <driverlib/vims.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/components/services/src/saddr/saddr.c b/simplelink/ble_sdk_2_02_01_18/src/components/services/src/saddr/saddr.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/components/services/src/saddr/saddr.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/components/services/src/saddr/saddr.c	2017-06-21 04:32:09.387098222 -0400
+@@ -48,7 +48,7 @@
+  * INCLUDES
+  */
+ #include "hal_types.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "saddr.h"
+ 
+ /****************************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/blood_pressure/cc26xx/app/blood_pressure.c b/simplelink/ble_sdk_2_02_01_18/src/examples/blood_pressure/cc26xx/app/blood_pressure.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/blood_pressure/cc26xx/app/blood_pressure.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/blood_pressure/cc26xx/app/blood_pressure.c	2017-06-21 04:32:09.387098222 -0400
+@@ -75,7 +75,7 @@
+ #include "util.h"
+ #include "board_key.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "utc_clock.h"
+ #include "blood_pressure.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/cycling_sensor/cc26xx/app/cycling_sensor.c b/simplelink/ble_sdk_2_02_01_18/src/examples/cycling_sensor/cc26xx/app/cycling_sensor.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/cycling_sensor/cc26xx/app/cycling_sensor.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/cycling_sensor/cc26xx/app/cycling_sensor.c	2017-06-21 04:32:09.387098222 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "cycling_sensor.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_a.c b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_a.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_a.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_a.c	2017-06-21 04:32:09.387098222 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "hal_mcu.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_b.c b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_b.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_b.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/dual_image_concept_img_b.c	2017-06-21 04:32:09.387098222 -0400
+@@ -68,7 +68,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/main.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/dual_image_concept/cc1350/app/main.c	2017-06-21 04:32:09.387098222 -0400
+@@ -77,7 +77,7 @@
+ #endif // !(USE_DEFAULT_USER_CFG || HAL_IMAGE_B)
+ #endif // !HAL_IMAGE_B
+ 
+-#include <board.h>
++#include <Board.h>
+ #include <ti/mw/display/Display.h>
+ 
+ /*******************************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_collector/cc26xx/app/glucose_collector.c b/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_collector/cc26xx/app/glucose_collector.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_collector/cc26xx/app/glucose_collector.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_collector/cc26xx/app/glucose_collector.c	2017-06-21 04:32:09.387098222 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include "board_key.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ #include "icall_apimsg.h"
+ #include "utc_clock.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_sensor/cc26xx/app/glucose.c b/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_sensor/cc26xx/app/glucose.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_sensor/cc26xx/app/glucose.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/glucose_sensor/cc26xx/app/glucose.c	2017-06-21 04:32:09.387098222 -0400
+@@ -72,7 +72,7 @@
+ 
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ #include "board_key.h"
+ #include "utc_clock.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/heart_rate.c b/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/heart_rate.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/heart_rate.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/heart_rate.c	2017-06-21 04:32:09.387098222 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "heart_rate.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/main.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/heart_rate/cc26xx/app/main.c	2017-06-21 04:32:09.387098222 -0400
+@@ -55,7 +55,7 @@
+ 
+ #include "icall.h"
+ #include "hal_assert.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "bcomdef.h"
+ #include "peripheral.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/hid_adv_remote.c b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/hid_adv_remote.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/hid_adv_remote.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/hid_adv_remote.c	2017-06-21 04:32:09.387098222 -0400
+@@ -62,7 +62,7 @@
+ #include <ti/mw/remotecontrol/buzzer.h>
+ #include <ti/drivers/pdm/PDMCC26XX.h>
+ 
+-#include <ICall.h>
++#include <icall.h>
+ #include <string.h>
+ #include "hci.h"
+ #include "gatt.h"
+@@ -79,7 +79,7 @@
+ #include "osal_snv.h"
+ #include "icall_apimsg.h"
+ #include "util.h"
+-#include "board.h"
++#include "Board.h"
+ #include "kcb.h"
+ #include "key_scan.h"
+ #include "hid_adv_remote.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/main.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_adv_remote/cc26xx/app/main.c	2017-06-21 04:32:09.397098163 -0400
+@@ -56,7 +56,7 @@
+ 
+ #include "icall.h"
+ #include "hal_assert.h"
+-#include "board.h"
++#include "Board.h"
+ #include "bcomdef.h"
+ #include "peripheral.h"
+ #include "hiddev.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_emu_kbd/cc26xx/app/hidemukbd.c b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_emu_kbd/cc26xx/app/hidemukbd.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/hid_emu_kbd/cc26xx/app/hidemukbd.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/hid_emu_kbd/cc26xx/app/hidemukbd.c	2017-06-21 04:32:09.397098163 -0400
+@@ -74,7 +74,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "hidemukbd.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/host_test/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/host_test/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/host_test/cc26xx/app/main.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/host_test/cc26xx/app/main.c	2017-06-21 04:32:09.397098163 -0400
+@@ -55,7 +55,7 @@
+ 
+ #include "icall.h"
+ #include "hal_assert.h"
+-#include "board.h"
++#include "Board.h"
+ #include "inc/npi_task.h"
+ 
+ #include "host_test_app.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/key_fob/cc26xx/app/keyfobdemo.c b/simplelink/ble_sdk_2_02_01_18/src/examples/key_fob/cc26xx/app/keyfobdemo.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/key_fob/cc26xx/app/keyfobdemo.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/key_fob/cc26xx/app/keyfobdemo.c	2017-06-21 04:32:09.397098163 -0400
+@@ -79,7 +79,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "keyfobdemo.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/oad_target/cc26xx/app/oad_target_app.c b/simplelink/ble_sdk_2_02_01_18/src/examples/oad_target/cc26xx/app/oad_target_app.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/oad_target/cc26xx/app/oad_target_app.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/oad_target/cc26xx/app/oad_target_app.c	2017-06-21 04:32:09.397098163 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/proximity_tag/cc26xx/app/proximity_tag.c b/simplelink/ble_sdk_2_02_01_18/src/examples/proximity_tag/cc26xx/app/proximity_tag.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/proximity_tag/cc26xx/app/proximity_tag.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/proximity_tag/cc26xx/app/proximity_tag.c	2017-06-21 04:32:09.397098163 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ #include "buzzer.h"
+ 
+ #include "proximity_tag.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/main.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/main.c	2017-06-21 04:32:09.397098163 -0400
+@@ -56,7 +56,7 @@
+ 
+ #include "icall.h"
+ #include "hal_assert.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "bcomdef.h"
+ #include "peripheral.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/running_sensor.c b/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/running_sensor.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/running_sensor.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/running_sensor/cc26xx/app/running_sensor.c	2017-06-21 04:32:09.397098163 -0400
+@@ -73,7 +73,7 @@
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "running_sensor.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/devpk_light.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/devpk_light.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/devpk_light.c	2017-06-21 04:29:46.287938688 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/devpk_light.c	2017-06-21 04:32:09.397098163 -0400
+@@ -52,7 +52,7 @@
+ // Temporary PWM solution directly on DriverLib
+ // (until a Timer RTOS driver is in place)
+ #include <ti/drivers/pin/PINCC26XX.h>
+-#include <driverLib/timer.h>
++#include <driverlib/timer.h>
+ 
+ #include "devpk_light.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_audio.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_audio.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_audio.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_audio.c	2017-06-21 04:32:09.397098163 -0400
+@@ -62,7 +62,7 @@
+ 
+ #include "sensortag.h"
+ #include "sensortag_audio.h"
+-#include "board.h"
++#include "Board.h"
+ #include "util.h"
+ #include "string.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_bar.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_bar.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_bar.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_bar.c	2017-06-21 04:32:09.397098163 -0400
+@@ -58,7 +58,7 @@
+ #include "sensortag_bar.h"
+ #include "SensorTagTest.h"
+ #include "SensorBmp280.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include <ti/sysbios/knl/Semaphore.h>
+ #include <ti/sysbios/knl/Task.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_buzzer.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_buzzer.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_buzzer.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_buzzer.c	2017-06-21 04:32:09.397098163 -0400
+@@ -57,7 +57,7 @@
+ // Temporary PWM solution directly on DriverLib
+ // (until a Timer RTOS driver is in place)
+ #include <ti/drivers/pin/PINCC26XX.h>
+-#include <driverLib/timer.h>
++#include <driverlib/timer.h>
+ 
+ #include "sensortag_buzzer.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.c	2017-06-21 04:32:09.397098163 -0400
+@@ -57,7 +57,7 @@
+ #include <ti/sysbios/knl/Queue.h>
+ #include <ti/sysbios/knl/Task.h>
+ 
+-#include <ICall.h>
++#include <icall.h>
+ 
+ #include "gatt.h"
+ #include "hci.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_conn_ctrl.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_conn_ctrl.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_conn_ctrl.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_conn_ctrl.c	2017-06-21 04:32:09.397098163 -0400
+@@ -56,7 +56,7 @@
+ #include "sensortag_conn_ctrl.h"
+ #include "ccservice.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "peripheral.h"
+ 
+ #include <ti/sysbios/knl/Semaphore.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.h b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.h	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag.h	2017-06-21 04:32:09.397098163 -0400
+@@ -56,7 +56,7 @@
+ /*********************************************************************
+  * INCLUDES
+  */
+-#include "ICall.h"
++#include "icall.h"
+ #include "peripheral.h"
+ #include <ti/sysbios/knl/Clock.h>
+ #include <ti/drivers/PIN.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_hum.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_hum.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_hum.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_hum.c	2017-06-21 04:32:09.397098163 -0400
+@@ -52,7 +52,7 @@
+  */
+ #include "gatt.h"
+ #include "gattservapp.h"
+-#include "board.h"
++#include "Board.h"
+ #include "string.h"
+ 
+ #include "humidityservice.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.c	2017-06-21 04:32:09.397098163 -0400
+@@ -58,7 +58,7 @@
+ 
+ #include <ti/sysbios/knl/Semaphore.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "peripheral.h"
+ #include "util.h"
+ #include "SensorMpu9250.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.h b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.h	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_io.h	2017-06-21 04:32:09.397098163 -0400
+@@ -57,7 +57,7 @@
+  * INCLUDES
+  */
+ #include "sensortag.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_keys.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_keys.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_keys.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_keys.c	2017-06-21 04:32:09.397098163 -0400
+@@ -57,7 +57,7 @@
+ #include "sensortag_io.h"
+ #include "ioservice.h"
+ #include "sensortag_factoryreset.h"
+-#include "board.h"
++#include "Board.h"
+ #include "peripheral.h"
+ #include "simplekeys.h"
+ #include "sensortag_audio.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_light.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_light.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_light.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_light.c	2017-06-21 04:32:09.397098163 -0400
+@@ -62,7 +62,7 @@
+ #include <ti/drivers/power/PowerCC26XX.h>
+ #endif
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "bcomdef.h"
+ #include "sensortag.h"
+ #include "devpk_light.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_lp.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_lp.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_lp.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_lp.c	2017-06-21 04:32:09.407098104 -0400
+@@ -54,7 +54,7 @@
+ #include <ti/sysbios/knl/Semaphore.h>
+ #include <ti/sysbios/knl/Task.h>
+ 
+-#include <ICall.h>
++#include <icall.h>
+ 
+ #include "gatt.h"
+ #include "hci.h"
+@@ -65,7 +65,7 @@
+ #include "util.h"
+ #include "icall_apimsg.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "ExtFlash.h"
+ 
+ #include "sensortag.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_mov.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_mov.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_mov.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_mov.c	2017-06-21 04:32:09.407098104 -0400
+@@ -57,7 +57,7 @@
+ #include "gatt.h"
+ #include "gattservapp.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ #include "movementservice.h"
+ #include "sensortag_mov.h"
+ #include "SensorMpu9250.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_oad.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_oad.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_oad.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_oad.c	2017-06-21 04:32:09.407098104 -0400
+@@ -50,7 +50,7 @@
+  */
+ #include "bcomdef.h"
+ #include "string.h"
+-#include <ICall.h>
++#include <icall.h>
+ #include "util.h"
+ #include "sensortag.h"
+ #include "sensortag_conn_ctrl.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_opt.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_opt.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_opt.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_opt.c	2017-06-21 04:32:09.407098104 -0400
+@@ -61,7 +61,7 @@
+ #include "sensortag_opt.h"
+ #include "SensorOpt3001.h"
+ #include "SensorTagTest.h"
+-#include "board.h"
++#include "Board.h"
+ #include "util.h"
+ #include "string.h"
+ /*********************************************************************
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_register.h b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_register.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_register.h	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_register.h	2017-06-21 04:32:09.407098104 -0400
+@@ -56,7 +56,7 @@
+ /*********************************************************************
+  * INCLUDES
+  */
+-#include "sensorTag.h"
++#include "sensortag.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_tmp.c b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_tmp.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_tmp.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/sensortag/cc26xx/app/sensortag_tmp.c	2017-06-21 04:32:09.407098104 -0400
+@@ -58,7 +58,7 @@
+ #include "SensorTmp007.h"
+ #include "SensorTagTest.h"
+ #include "SensorUtil.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "string.h"
+ #include <ti/sysbios/knl/Semaphore.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650em/board_cc2650em.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650em/board_cc2650em.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650em/board_cc2650em.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650em/board_cc2650em.c	2017-06-21 04:32:09.407098104 -0400
+@@ -63,7 +63,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650lp/board_cc2650lp.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650lp/board_cc2650lp.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650lp/board_cc2650lp.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650lp/board_cc2650lp.c	2017-06-21 04:32:09.407098104 -0400
+@@ -63,7 +63,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650stk/board_cc2650stk.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650stk/board_cc2650stk.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650stk/board_cc2650stk.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/board_cc2650stk/board_cc2650stk.c	2017-06-21 04:32:09.407098104 -0400
+@@ -63,7 +63,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/main.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/main.c	2017-06-21 04:32:09.407098104 -0400
+@@ -59,7 +59,7 @@
+ #include <ti/npi/npi_task.h>
+ 
+ #include <driverlib/ioc.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "simple_ap.h"
+ #include "hal_assert.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap.c	2017-06-21 04:32:09.407098104 -0400
+@@ -76,7 +76,7 @@
+ 
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap_no_keys.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap_no_keys.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap_no_keys.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_ap/cc26xx/app/simple_ap_no_keys.c	2017-06-21 04:32:09.407098104 -0400
+@@ -81,7 +81,7 @@
+ #include "simple_gatt_profile.h"
+ #include "simple_ap.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * CONSTANTS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_broadcaster/cc26xx/app/simple_broadcaster.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_broadcaster/cc26xx/app/simple_broadcaster.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_broadcaster/cc26xx/app/simple_broadcaster.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_broadcaster/cc26xx/app/simple_broadcaster.c	2017-06-21 04:32:09.407098104 -0400
+@@ -70,7 +70,7 @@
+ 
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "simple_broadcaster.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_central/cc26xx/app/simple_central.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_central/cc26xx/app/simple_central.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_central/cc26xx/app/simple_central.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_central/cc26xx/app/simple_central.c	2017-06-21 04:32:09.407098104 -0400
+@@ -72,7 +72,7 @@
+ #include "util.h"
+ #include "board_key.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "simple_central.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc1350lp/board_cc1350lp.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc1350lp/board_cc1350lp.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc1350lp/board_cc1350lp.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc1350lp/board_cc1350lp.c	2017-06-21 04:32:09.407098104 -0400
+@@ -70,7 +70,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650em/board_cc2650em.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650em/board_cc2650em.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650em/board_cc2650em.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650em/board_cc2650em.c	2017-06-21 04:32:09.407098104 -0400
+@@ -62,7 +62,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650lp/board_cc2650lp.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650lp/board_cc2650lp.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650lp/board_cc2650lp.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/board_cc2650lp/board_cc2650lp.c	2017-06-21 04:32:09.407098104 -0400
+@@ -63,7 +63,7 @@
+ #include <driverlib/ioc.h>
+ #include <driverlib/udma.h>
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*
+  *  ========================= IO driver initialization =========================
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/main.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/main.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/main.c	2017-06-21 04:29:46.297938629 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/main.c	2017-06-21 04:32:09.407098104 -0400
+@@ -68,7 +68,7 @@
+ 
+ #include "icall.h"
+ #include "hal_assert.h"
+-#include "board.h"
++#include "Board.h"
+ #include <driverlib/sys_ctrl.h>
+ 
+ #include "bcomdef.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/simple_np.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/simple_np.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/simple_np.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_np/cc26xx/app/simple_np.c	2017-06-21 04:32:09.407098104 -0400
+@@ -77,7 +77,7 @@
+ 
+ #include "util.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #ifdef SNP_LOCAL
+ #include <ti/sap/snp_rpc_synchro.h>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_observer/cc26xx/app/simple_observer.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_observer/cc26xx/app/simple_observer.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_observer/cc26xx/app/simple_observer.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_observer/cc26xx/app/simple_observer.c	2017-06-21 04:32:09.407098104 -0400
+@@ -68,7 +68,7 @@
+ #include "util.h"
+ #include "board_key.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+    
+ #include "simple_observer.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_peripheral/cc26xx/app/simple_peripheral.c b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_peripheral/cc26xx/app/simple_peripheral.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/simple_peripheral/cc26xx/app/simple_peripheral.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/simple_peripheral/cc26xx/app/simple_peripheral.c	2017-06-21 04:32:09.417098045 -0400
+@@ -83,7 +83,7 @@
+ #include <ti/mw/display/Display.h>
+ #include "board_key.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "simple_peripheral.h"
+ 
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/thermometer/cc26xx/app/thermometer.c b/simplelink/ble_sdk_2_02_01_18/src/examples/thermometer/cc26xx/app/thermometer.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/thermometer/cc26xx/app/thermometer.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/thermometer/cc26xx/app/thermometer.c	2017-06-21 04:32:09.417098045 -0400
+@@ -78,7 +78,7 @@
+ #include "time_clock.h"
+ #include "bletime.h"
+ 
+-#include "board.h"
++#include "Board.h"
+ 
+ /*********************************************************************
+  * MACROS
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_app.c b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_app.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_app.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_app.c	2017-06-21 04:32:09.417098045 -0400
+@@ -71,7 +71,7 @@
+ #include "util.h"
+ #include "board_key.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ 
+ #include "utc_clock.h"
+ #include "time_clock.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_config.c b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_config.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_config.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_config.c	2017-06-21 04:32:09.417098045 -0400
+@@ -50,7 +50,7 @@
+ 
+ #include "bcomdef.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ #include "gatt.h"
+ #include "gatt_uuid.h"
+ #include "gattservapp.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_ind.c b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_ind.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_ind.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/examples/time_app/cc26xx/app/time_ind.c	2017-06-21 04:32:09.417098045 -0400
+@@ -50,7 +50,7 @@
+ #include "string.h"
+ #include "bcomdef.h"
+ #include <ti/mw/display/Display.h>
+-#include "board.h"
++#include "Board.h"
+ #include "gatt.h"
+ #include "gatt_uuid.h"
+ #include "gattservapp.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/icall/app/ble_user_config.c b/simplelink/ble_sdk_2_02_01_18/src/icall/app/ble_user_config.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/icall/app/ble_user_config.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/icall/app/ble_user_config.c	2017-06-21 04:32:09.417098045 -0400
+@@ -51,7 +51,7 @@
+ 
+ #include "hal_types.h"
+ #include "ble_user_config.h"
+-#include <ti/drivers/rf/rf.h>
++#include <ti/drivers/rf/RF.h>
+ 
+ #if defined(BLE_V42_FEATURES) && (BLE_V42_FEATURES & SECURE_CONNS_CFG)
+ #include "ecc/ECCROMCC26XX.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/icall/inc/ble_user_config.h b/simplelink/ble_sdk_2_02_01_18/src/icall/inc/ble_user_config.h
+--- a/simplelink/ble_sdk_2_02_01_18/src/icall/inc/ble_user_config.h	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/icall/inc/ble_user_config.h	2017-06-21 04:32:09.417098045 -0400
+@@ -154,7 +154,7 @@
+ // CC2650STK           CC2650EM_7ID
+ // CC1350_LAUNCHXL     CC1350LP_7XD
+ // CC1350STK           CC1350EM_7ID
+-#include "board.h"
++#include "Board.h"
+ 
+ // RF Front End Settings
+ // Note: The use of these values completely depends on how the PCB is laid out.
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/src/profiles/audio/audio_profile.c b/simplelink/ble_sdk_2_02_01_18/src/profiles/audio/audio_profile.c
+--- a/simplelink/ble_sdk_2_02_01_18/src/profiles/audio/audio_profile.c	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/src/profiles/audio/audio_profile.c	2017-06-21 04:32:09.417098045 -0400
+@@ -50,7 +50,7 @@
+  */
+ #include <string.h>
+ #include "bcomdef.h"
+-#include "OSAL.h"
++#include "osal.h"
+ #include "linkdb.h"
+ #include "att.h"
+ #include "gatt.h"
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc1350.xml b/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc1350.xml
+--- a/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc1350.xml	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc1350.xml	2017-06-21 04:32:09.417098045 -0400
+@@ -17,7 +17,7 @@
+ <libraries>
+ 	<library>
+ 		<name>Host</name>
+-		<searchpath>.\host</searchpath>
++		<searchpath>./host</searchpath>
+ 		<outputnameadd>_host</outputnameadd>
+ 		<matchconfig>1</matchconfig>
+ 		<parameterlist>
+@@ -63,7 +63,7 @@
+ 	</library>
+ 	<library>
+ 		<name>Controller</name>
+-		<searchpath>.\ctrl\cc1350</searchpath>
++		<searchpath>./ctrl/cc1350</searchpath>
+ 		<outputnameadd>_ctrl</outputnameadd>
+ 		<matchconfig>1</matchconfig>
+ 		<parameterlist>
+@@ -106,7 +106,7 @@
+ 	</library>
+ 	<library>
+ 		<name>HCI_TL</name>
+-		<searchpath>.\hci_tl\cc26xx</searchpath>
++		<searchpath>./hci_tl/cc26xx</searchpath>
+ 		<outputnameadd>_hci_tl</outputnameadd>
+ 		<matchconfig>0</matchconfig>
+ 		<parameterlist>
+diff -r -u a/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc2640.xml b/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc2640.xml
+--- a/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc2640.xml	2017-06-21 04:29:46.307938570 -0400
++++ b/simplelink/ble_sdk_2_02_01_18/tools/lib_search/params_split_cc2640.xml	2017-06-21 04:32:09.417098045 -0400
+@@ -17,7 +17,7 @@
+ <libraries>
+ 	<library>
+ 		<name>Host</name>
+-		<searchpath>.\host</searchpath>
++		<searchpath>./host</searchpath>
+ 		<outputnameadd>_host</outputnameadd>
+ 		<matchconfig>1</matchconfig>
+ 		<parameterlist>
+@@ -63,7 +63,7 @@
+ 	</library>
+ 	<library>
+ 		<name>Controller</name>
+-		<searchpath>.\ctrl\cc2640</searchpath>
++		<searchpath>./ctrl/cc2640</searchpath>
+ 		<outputnameadd>_ctrl</outputnameadd>
+ 		<matchconfig>1</matchconfig>
+ 		<parameterlist>
+@@ -106,7 +106,7 @@
+ 	</library>
+ 	<library>
+ 		<name>HCI_TL</name>
+-		<searchpath>.\hci_tl\cc26xx</searchpath>
++		<searchpath>./hci_tl/cc26xx</searchpath>
+ 		<outputnameadd>_hci_tl</outputnameadd>
+ 		<matchconfig>0</matchconfig>
+ 		<parameterlist>
+diff -r -u a/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages/ti/mw/remotecontrol/buzzer.c b/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages/ti/mw/remotecontrol/buzzer.c
+--- a/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages/ti/mw/remotecontrol/buzzer.c	2017-06-21 04:29:46.307938570 -0400
++++ b/tirtos_cc13xx_cc26xx_2_20_01_08/products/tidrivers_cc13xx_cc26xx_2_20_01_10/packages/ti/mw/remotecontrol/buzzer.c	2017-06-21 04:32:09.417098045 -0400
+@@ -49,7 +49,7 @@
+ // Temporary PWM solution directly on DriverLib
+ // (until a Timer RTOS driver is in place)
+ #include <ti/drivers/pin/PINCC26XX.h>
+-#include <driverLib/timer.h>
++#include <driverlib/timer.h>
+ 
+ #include "buzzer.h"
+ 


### PR DESCRIPTION
Generated by: diff -r -u a b
where a is stock ti root directory, and b is converted ti root
directory after running the convert script.

Apply in ti root directory with: patch -p0 < ti_ble_sdk_2_02_01_18.patch

Users might be interested only in the end-result: the patch.